### PR TITLE
Optionally read seed from URL params

### DIFF
--- a/scripts/board.js
+++ b/scripts/board.js
@@ -1,3 +1,5 @@
+const urlParams = new URLSearchParams(window.location.search);
+
 var randpos = 0
 
 //init
@@ -5,7 +7,10 @@ $("#seed").keyup(function() {
 		fire();
 });
 
-$("#seed").val(Math.floor(Math.random() * 1000));
+
+$("#seed").val(
+	urlParams.get('seed') || Math.floor(Math.random() * 1000)
+);
 fire();
 
 function clearboard(){


### PR DESCRIPTION
Read the seed from the URL params. I wanted to be able to send a page to my friend to play online without having to tell them to type in the seed. 

This doesn't sync the state to the URL params, so it's not perfect yet. We should do that next if we want to proceed down this route. (if you click new seed, the url and the page will be out of sync)

**testing:**
loaded: `file:///D:/code/GitHub/telewave/index.html?seed=999`
see: seed is 999


loaded: `file:///D:/code/GitHub/telewave/index.html`
see: seed is randomly generated
